### PR TITLE
Adjust ZED-F9P driver configuration

### DIFF
--- a/config/driver_config.yaml
+++ b/config/driver_config.yaml
@@ -4,7 +4,7 @@
 online: 1           # input from serial port(1) or file(0)
 ## if `online == 1` then following options may be set
 input_serial_port: "/dev/ttyACM0"
-serial_baud_rate: 921600
+serial_baud_rate: 115200
 input_rtcm: 0       # whether input RTCM data to receiver for RTK solution
 rtcm_tcp_port: 3503
 config_receiver_at_start: 0     # whether to config receiver during booting, ** NOT SUPPORT YET **
@@ -19,7 +19,7 @@ rtk_correction_ecef:      # apply RTK correction in case of the position of base
 
 # output options
 to_ros: 1           # publish as ros topic
-to_file: 0          # dump data to file
+to_file: 1          # dump data to file
 dump_dir: "~/tmp/ublox_driver_test/"      # dump data to this directory, if applicable
 to_serial: 0        # output data to serial port, for debugging purpose
 output_serial_port: "/dev/ttyACM0"                  # dump data to this serial port, if applicable


### PR DESCRIPTION
Dump recorded data to .ubx file, too.
Use different baud rate.